### PR TITLE
Fixed the link to the Astyle Download

### DIFF
--- a/Development-Guide/Style-Guide/README.adoc
+++ b/Development-Guide/Style-Guide/README.adoc
@@ -19,7 +19,7 @@ Follow AStyle, bindings are available in sublime and vim.
 To install the latest version in debian based operating systems:
 
 ```bash
-wget 'https://sourceforge.net/projects/astyle/files/latest/download'
+wget 'https://sourceforge.net/projects/astyle/files/astyle/astyle%202.06/astyle_2.06_linux.tar.gz/download'
 tar -zxvf download
 cd astyle/build/gcc
 make release


### PR DESCRIPTION
The previous link led to the windows version of Astyle, causing a lot of Travis Builds to fail, the link will have to be updated in all the files that use it on the Travis build. S/O to Jannis for bringing this up.